### PR TITLE
Update output filename format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ glimmer-grabber is a tool designed to help users digitize their Lorcana trading 
 - **Image capture:** Capturing high-quality images of individual Lorcana cards.
 - **Card identification:** Identifying the card name, set, and other relevant information from the captured image.
 - **Data management:** Storing and organizing digitized card data, including images and metadata.
-- **Export:** Exporting the digitized card collection data in various formats (e.g., CSV, JSON).
+- **Export:** Exporting the digitized card collection data in various formats (e.g., CSV, JSON). The exported CSV file will be named `lorcana_collection_{n}.csv`, where `n` is an incrementing number to avoid overwriting existing files.
 
 ## Problem Solved
 

--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -41,7 +41,16 @@ def generate_csv(card_data: List[dict], output_path: str) -> None:
         card_data: A list of dictionaries, where each dictionary represents a card.
         output_path: The path to the output directory.
     """
-    csv_file_path: str = os.path.join(output_path, "card_data.csv")
+    n = 1
+    while True:
+        csv_file_path = os.path.join(output_path, f"lorcana_collection_{n}.csv")
+        if not os.path.exists(csv_file_path):
+            break
+        n += 1
+
+    # Generates a unique filename for the CSV output to prevent overwriting existing files.
+    # The filename follows the format "lorcana_collection_{n}.csv", where 'n' is an incrementing number.
+    # The function checks for existing files with this pattern and increments 'n' until a unique filename is found.
     if not os.path.exists(output_path):
         os.makedirs(output_path)
     with open(csv_file_path, mode="w", newline="", encoding="utf-8") as csvfile:


### PR DESCRIPTION
The output filename format has been changed to `lorcana_collection_{n}.csv`, where `n` is an incrementing integer. This change prevents overwriting existing files and provides a more descriptive filename. The README has been updated to reflect this change, and a comment has been added to the `generate_csv` function to explain the new logic.