### PR TITLE
Fix build failure and address configuration warnings.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "glimmer-grabber"
 version = "0.1.0"
 description = "Tooling for digitizing Lorcana Trading Cards."
 authors = [{ name = "Your Name", email = "your.email@example.com" }]  # Replace with actual author info if available
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.7"
 dependencies = [
     "numpy",
@@ -14,12 +14,12 @@ dependencies = [
 ]
 
 [project.scripts]
-glimmer-grabber = "glimmer_grabber.cli:main"  # CLI Entry Point
+glimmer-grabber = "app.cli:main"  # CLI Entry Point
 
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["glimmer_grabber"]
+packages = ["app", "core", "utils"]
 package-dir = {"" = "src"}


### PR DESCRIPTION
The build was failing due to a mismatch between the configured package directory and the actual project structure. This commit updates `pyproject.toml` to correctly reflect the project layout by adjusting the `packages` and entry point configurations.

Additionally, the license declaration in `pyproject.toml` has been updated to use the SPDX identifier "MIT" to address a Setuptools deprecation warning.

Please remember to update pip to the latest version by running: `pip install --upgrade pip`