### PR TITLE
Fix: Resolve import error by using a relative import path.

### DIFF
--- a/src/app/cli.py
+++ b/src/app/cli.py
@@ -6,7 +6,7 @@ import csv  # Import the csv module
 from typing import List
 from .config_manager import ConfigManager
 from .image_reader import read_images_from_folder
-from src.core.image_processor import process_images
+from ..core.image_processor import process_images
 from .card_data_fetcher import CardDataFetcher  # Import the CardDataFetcher class
 """Command-line interface for the card processing application."""
 


### PR DESCRIPTION
The import statement for `process_images` in `src/app/cli.py` was using an absolute path, causing an import error when the script was run from certain locations. This commit changes the import statement to use a relative path, resolving the issue.