### PR TITLE
Fix: Remove non-existent text-encoding package from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         pip install -r job_service/requirements.txt
         pip install -r processing_service/requirements.txt
         pip install -r auth_service/requirements.txt
-        pip install pytest moto passlib python-multipart fuzzywuzzy text-encoding
+        pip install pytest moto passlib python-multipart fuzzywuzzy
         pip install -e shared
         sudo apt-get update && sudo apt-get install -y tesseract-ocr
 


### PR DESCRIPTION
The CI build was failing because it was trying to install a non-existent package `text-encoding`. This package is not on PyPI and was likely a typo.

This commit removes the `text-encoding` package from the `pip install` command in the `.github/workflows/ci.yml` file.