### PR TITLE
Fix: Update Node.js version to fix Jest TypeError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: Install frontend dependencies
       run: npm install --prefix my-react-app


### PR DESCRIPTION
The Jest tests were failing with a `TypeError: (0 , _os(...).availableParallelism) is not a function`. This is because Jest 30 requires Node.js version 18 or higher, but the CI environment was using Node.js version 16.

This commit updates the Node.js version in the `.github/workflows/ci.yml` file from 16 to 18 to resolve the issue.